### PR TITLE
Fixed improper return in matrix() function when inline=False

### DIFF
--- a/missingno/missingno.py
+++ b/missingno/missingno.py
@@ -311,7 +311,7 @@ def matrix(df,
     if inline:
         plt.show()
     else:
-        return plt
+        return fig
 
 
 def bar(df, figsize=(24, 10), fontsize=16, labels=None, log=False, color=(0.25, 0.25, 0.25), inline=True,


### PR DESCRIPTION
This PR addresses issue #27 by changing a line in the definition of `matrix`. 