### PR TITLE
Implement columnar sorting in bar and heatmap.

### DIFF
--- a/missingno/utils.py
+++ b/missingno/utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 
-def nullity_sort(df, sort=None):
+def nullity_sort(df, sort=None, axis='columns'):
     """
     Sorts a DataFrame according to its nullity, in either ascending or descending order.
 
@@ -10,12 +10,24 @@ def nullity_sort(df, sort=None):
     :param sort: The sorting method: either "ascending", "descending", or None (default).
     :return: The nullity-sorted DataFrame.
     """
-    if sort == 'ascending':
-        return df.iloc[np.argsort(df.count(axis='columns').values), :]
-    elif sort == 'descending':
-        return df.iloc[np.flipud(np.argsort(df.count(axis='columns').values)), :]
-    else:
+    if sort is None:
         return df
+    elif sort not in ['ascending', 'descending']:
+        raise ValueError('The "sort" parameter must be set to "ascending" or "descending".')
+
+    if axis not in ['rows', 'columns']:
+        raise ValueError('The "axis" parameter must be set to "rows" or "columns".')
+
+    if axis == 'columns':
+        if sort == 'ascending':
+            return df.iloc[np.argsort(df.count(axis='columns').values), :]
+        elif sort == 'descending':
+            return df.iloc[np.flipud(np.argsort(df.count(axis='columns').values)), :]
+    elif axis == 'rows':
+        if sort == 'ascending':
+            return df.iloc[:, np.argsort(df.count(axis='rows').values)]
+        elif sort == 'descending':
+            return df.iloc[:, np.flipud(np.argsort(df.count(axis='rows').values))]
 
 
 def nullity_filter(df, filter=None, p=0, n=0):


### PR DESCRIPTION
This PR addresses #86 and supersedes #84.

The `sort` parameter performs a row-major sort on the elements of the input `DataFrame` based on the nullity count of the entry. An `"ascending"` sort will sort rows from low to high, whilst a `"descending"` sort will sort rows from high to low.

This is a useful feature of `msno.matrix` because it allows you optionally inject some order into the resultant matrix. However, this does nothing for any of the remaining plot types because every other plot type in `missingno` is row-sort independent. E.g. resorting the data will have no effect on the total null count, which is what `bar` cares about, nor the correlation score, which is what `heatmap` cares about (and so on).

For two of these other plot types (`heatmap` and `bar`), a column-sort makes sense; e.g. it makes sense to sort the *columns* based on how many cumulative null values they have. This PR implements this behavior for the `sort` parameter on these plots, using a `axis={"rows", "columns"}` internal argument on `missingno.utils.nullity_sort`.

There is admittedly a little bit of user surprise implicit in the swap of sort direction from one plot to another, but I think it makes sense to implement things this way. It doesn't make sense to change the sort axis in `msno.matrix`, as in #84, because that is much less useful to the user. If you want that, just use `msno.bar` instead.

This PR also removes the `sort` parameter and `nullity_sort` call for the plots for which sorting the `DataFrame` before plotting does not do anything regardless of sort order: `geoplot` and `dendrogram`.