### PR TITLE
Deprecate the geoplot function.

### DIFF
--- a/missingno/missingno.py
+++ b/missingno/missingno.py
@@ -491,7 +491,24 @@ def geoplot(df,
     :param kwargs: Additional keyword arguments are passed to the underlying `geoplot` function.
     :return: If `inline` is False, the underlying `matplotlib.figure` object. Else, nothing.
     """
-    import geoplot as gplt
+    warnings.warn(
+        "The 'geoplot' function has been deprecated, and will be removed in a future version "
+        "of missingno. The 'geoplot' package has an example recipe for a more full-featured "
+        "geospatial nullity plot: "
+        "https://residentmario.github.io/geoplot/gallery/plot_san_francisco_trees.html"
+    )
+    try:
+        import geoplot as gplt
+    except ImportError:
+        raise ImportError("Install geoplot <= 0.2.4 (the package) for geoplot function support")
+
+    if gplt.__version__ >= "0.3.0":
+        raise ImportError(
+            f"The missingno geoplot function requires geoplot package version 0.2.4 or lower, "
+            f"but version {gplt.__version__} is installed instead. To use the geoplot function, "
+            f"downgrade to an older version of the geoplot package."
+        )
+
     import geopandas as gpd
     from shapely.geometry import Point
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -134,7 +134,7 @@ class TestGeoplot(unittest.TestCase):
         self.x_y_df = simple_df
 
     # @pytest.mark.mpl_image_compare
-    @pytest.xfail
+    @pytest.mark.xfail
     def test_geoplot_quadtree(self):
         msno.geoplot(self.x_y_df, x='r0', y='r1')
         return plt.gcf()


### PR DESCRIPTION
This very rarely used functionality is now a `geoplot` (package) recipe. For an example, see the [San Francisco Street Trees example](https://residentmario.github.io/geoplot/gallery/plot_san_francisco_trees.html) in the `geoplot` gallery.