### PR TITLE
Introduce orientation to bar plot

### DIFF
--- a/missingno/missingno.py
+++ b/missingno/missingno.py
@@ -204,7 +204,7 @@ def matrix(df,
 
 
 def bar(df, figsize=(24, 10), fontsize=16, labels=None, log=False, color='dimgray', inline=False,
-        filter=None, n=0, p=0, sort=None, ax=None):
+        filter=None, n=0, p=0, sort=None, ax=None, orientation=None):
     """
     A bar chart visualization of the nullity of the given DataFrame.
 
@@ -219,21 +219,31 @@ def bar(df, figsize=(24, 10), fontsize=16, labels=None, log=False, color='dimgra
     :param labels: Whether or not to display the column names. Would need to be turned off on particularly large
     displays. Defaults to True.
     :param color: The color of the filled columns. Default to the RGB multiple `(0.25, 0.25, 0.25)`.
+    :param orientation: The way the bar plot is oriented. Defaults to vertical if there are less than or equal to 50
+    columns and horizontal if there are more.
     :return: If `inline` is False, the underlying `matplotlib.figure` object. Else, nothing.
     """
     df = nullity_filter(df, filter=filter, n=n, p=p)
     df = nullity_sort(df, sort=sort, axis='rows')
     nullity_counts = len(df) - df.isnull().sum()
 
+    if not orientation:
+        if len(df.columns) > 50:
+            orientation = 'left'
+        else:
+            orientation = 'bottom'
+           
     if ax is None:
         ax1 = plt.gca()
     else:
         ax1 = ax
         figsize = None  # for behavioral consistency with other plot types, re-use the given size
 
-    (nullity_counts / len(df)).plot.bar(
-        figsize=figsize, fontsize=fontsize, log=log, color=color, ax=ax1
-    )
+    plot_args = {'figsize': figsize, 'fontsize': fontsize, 'log': log, 'color': color, 'ax': ax1}
+    if orientation == 'bottom':
+        (nullity_counts / len(df)).plot.bar(**plot_args)
+    else:
+        (nullity_counts / len(df)).plot.barh(**plot_args)                      
 
     axes = [ax1]
 

--- a/missingno/missingno.py
+++ b/missingno/missingno.py
@@ -203,13 +203,13 @@ def matrix(df,
         return ax0
 
 
-def bar(df, figsize=(24, 10), fontsize=16, labels=None, log=False, color='dimgray', inline=False,
+def bar(df, figsize=None, fontsize=16, labels=None, log=False, color='dimgray', inline=False,
         filter=None, n=0, p=0, sort=None, ax=None, orientation=None):
     """
     A bar chart visualization of the nullity of the given DataFrame.
 
     :param df: The input DataFrame.
-    :param log: Whether or not to display a logorithmic plot. Defaults to False (linear).
+    :param log: Whether or not to display a logarithmic plot. Defaults to False (linear).
     :param filter: The filter to apply to the heatmap. Should be one of "top", "bottom", or None (default).
     :param n: The cap on the number of columns to include in the filtered DataFrame.
     :param p: The cap on the percentage fill of the columns in the filtered DataFrame.
@@ -235,12 +235,14 @@ def bar(df, figsize=(24, 10), fontsize=16, labels=None, log=False, color='dimgra
            
     if ax is None:
         ax1 = plt.gca()
+        if figsize is None:
+            if len(df.columns) <= 50 or orientation == 'top' or orientation == 'bottom':
+                figsize = (25, 10)
+            else:
+                figsize = (25, (25 + len(df.columns) - 50) * 0.5)
     else:
         ax1 = ax
         figsize = None  # for behavioral consistency with other plot types, re-use the given size
-
-    if figsize is not None and orientation != 'bottom':
-        figsize = reversed(figsize)
 
     plot_args = {'figsize': figsize, 'fontsize': fontsize, 'log': log, 'color': color, 'ax': ax1}
     if orientation == 'bottom':


### PR DESCRIPTION
The dendrogram has an option to change the orientation from top-down to left-right. This is convenient when having a large amount of columns. The bar plot misses this option. To make the bar plot effective for large numbers of columns, it should have a similar behaviour. 

This pull requests adds the basic functionality. The `figsize` is not yet adjusted, this should be added.