### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.md
+
+include paper.bib
+include QuickStart.ipynb
+
+include postBuild
+include *.yml
+
+graft tests


### PR DESCRIPTION
Include some additional useful files in sdists.  In particular, include the license file, since the terms of the license requires it.  Also include tests, documentation, and files for downloading data if desired.