### PR TITLE
Correct return-type when inline=False

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -88,7 +88,7 @@ If you are not satisfied with these admittedly basic configuration parameters, t
 in any way you like using `matplotlib` post-facto.
 
 The best way to do this is to specify `inline=False`, which will cause `missingno` to return the underlying
-`matplotlib.figure.Figure` object. Anyone with sufficient knowledge of `matplotlib` operations and [the missingno source code](https://github.com/ResidentMario/missingno/blob/master/missingno/missingno.py)
+`matplotlib.axis.Axis` object of the main plot (e.g. only the matrix is returned when plotting the matrix with the sparkline). Anyone with sufficient knowledge of `matplotlib` operations and [the missingno source code](https://github.com/ResidentMario/missingno/blob/master/missingno/missingno.py)
 can then tweak the display to their liking. For example, the following code will bump the size of the dendrogram
 visualization's y-axis labels up from `20` to `30`:
 


### PR DESCRIPTION
The plot functions do not return `matplotlib.figure.Figure` instances but `matplotlib.axis.Axis` instances when `inline=False`. Technically, they can also return `matplotlib.axes._subplots.AxesSubplot` instances when we are dealing with subplots, but I have left this out for clarity and since the subplot class inherits from the axis class, making them behave in the same way essentially. If you prefer, I can clarify this return-type behaviour in the documentation as well.